### PR TITLE
fix: server hostname updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 // index.js
 const http = require('http');
 
-const hostname = '127.0.0.1'; 
+const hostname = '0.0.0.0'; 
 const port = 3000;
 
 const server = http.createServer((req, res) => {


### PR DESCRIPTION
Po zmianie hostname ze 127.0.0.1 na 0.0.0.0 możemy zbudować image oraz uruchomić go za pomocą `docker run -d -p 3000:3000 <name>` dzięki czemu serwer będzie dostępny spoza kontenera. Projekt był testowany na WSL